### PR TITLE
Fix compilation on OSX 10.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,11 @@ use_swephelp = True
 # Compile flags
 cflags = ['-std=gnu99']
 
+# Fix Clang error on OSX
+import sys
+if sys.platform == 'darwin':
+    cflags.append('-Wno-error=unused-command-line-argument-hard-error-in-future') 
+
 # Link flags
 ldflags = []
 


### PR DESCRIPTION
The new CLang compiler which ships with XCode 5.1 throws errors for unknown compiler flags. This patch ignores those errors until the issue is fixed upstream.

Basically, detects if the platform is darwin (OSX) and appends a new flag to 'cflags'.
