### PR TITLE
Define WIN32 for MSVC compilers

### DIFF
--- a/swephelp/swhwin.h
+++ b/swephelp/swhwin.h
@@ -21,6 +21,11 @@
 ** @brief swephelp windowz specific header
 */
 
+/* define WIN32 for MSVC compilers */
+#ifdef _WIN32
+#define WIN32
+#endif
+
 #ifndef SWHWIN_H
 #define SWHWIN_H
 


### PR DESCRIPTION
Microsoft Visual C++ compilers define _WIN32 (with underscore) instead of WIN32 as gcc does when compiling on Windows. Therefore, pyswisseph fails to compile with MSVC compiler.

This patch forces WIN32 to be defined if _WIN32 is defined by the MSVC compiler.
