### PR TITLE
Github Actions cibuildwheel on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build_wheels:
+    strategy:
+      matrix:
+        os: ['ubuntu-18.04', 'windows-latest', 'macos-latest']
+
+    name: Build wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+
+    - uses: actions/setup-python@v2
+      name: Install Python 3.7
+      with:
+        python-version: 3.7
+
+    - name: Install cibuildwheel
+      run: |
+        python -m pip install cibuildwheel==1.4.0
+
+    - name: Build wheel
+      run: |
+        python -m cibuildwheel --output-dir wheelhouse
+      env:
+        CIBW_BUILD: cp3?-*
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: wheels
+        path: ./wheelhouse

--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,8 @@
 *.zip
 
 MANIFEST
-build*
-dist*
+build/
+dist/
 doc
 epydoc/*
 make.py
@@ -24,3 +24,5 @@ swe_unix_src*
 swisseph.*.so
 swisseph.so
 
+venv/
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,8 @@ Usage example:
 """
 
 import os.path, sys
-from distutils.core import setup, Extension
+from setuptools import setup
+from distutils.core import Extension
 
 # Pyswisseph version string
 # Our version string gets the version of the swisseph library (x.xx.xx)
@@ -63,7 +64,7 @@ use_swephelp = True
 
 # Compile flags
 cflags = []
-if sys.platform == 'windows': # Windows
+if sys.platform in ['win32', 'win_amd64']: # Windows
     cflags.append('-D_CRT_SECURE_NO_WARNINGS')
 elif sys.platform == 'darwin': # OSX
     cflags.append('-Wno-error=unused-command-line-argument-hard-error-in-future')
@@ -228,7 +229,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules'
         ],
     keywords = 'Astrology Ephemeris Swisseph',
-    ext_modules = [swemodule]
+    ext_modules = [swemodule],
+    setup_requires = ['wheel']
     )
 
 # vi: set fenc=utf-8 ff=unix et sw=4 ts=4 sts=4 :


### PR DESCRIPTION
This PR will make it so every push to the repository triggers a wheel build with every push. (Only cpython 3 wheels)

This also edits .gitignore somewhat to ignore intellij-config folders, virtual environments, and errorously recognizing `build.yml`.

Wheels will be available under actions -> build # -> artifacts.

Example build: https://github.com/ShadowJonathan/pyswisseph/actions/runs/95035387

After a build has succeeded, uploads can be completed by following [this](https://cibuildwheel.readthedocs.io/en/stable/deliver-to-pypi/#manual-method) guide.

Closes #24