### PR TITLE
Add GHA build scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,85 +1,85 @@
 name: Build
 
 on:
-  push:
-  release:
-    types: [published]
+    push:
+    release:
+        types: [published]
 
 jobs:
-  build_src_wheel:
-    name: Build source wheel
-    runs-on: ubuntu-18.04
+    build_src_wheel:
+        name: Build source wheel
+        runs-on: ubuntu-18.04
 
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: recursive
 
-      - uses: actions/setup-python@v2
-        name: Install Python 3.7
-        with:
-          python-version: 3.7
+            - uses: actions/setup-python@v2
+              name: Install Python 3.7
+              with:
+                  python-version: 3.7
 
-      - name: Update to latest pip
-        run: |
-          python -m pip install -U setuptools pip wheel
+            - name: Update to latest pip
+              run: |
+                  python -m pip install -U setuptools pip wheel
 
-      - name: Build wheel
-        run: |
-          python setup.py sdist -d wheelhouse
+            - name: Build wheel
+              run: |
+                  python setup.py sdist -d wheelhouse
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: wheelhouse
+            - uses: actions/upload-artifact@v2
+              with:
+                  name: wheels
+                  path: wheelhouse
 
-  build_plat_wheels:
-    strategy:
-      matrix:
-        os: ["ubuntu-18.04", "windows-latest", "macos-latest"]
+    build_plat_wheels:
+        strategy:
+            matrix:
+                os: ["ubuntu-18.04", "windows-latest", "macos-latest"]
 
-    name: Build platform wheels on ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+        name: Build platform wheels on ${{ matrix.os }}
+        runs-on: ${{ matrix.os }}
 
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  submodules: recursive
 
-      - uses: actions/setup-python@v2
-        name: Install Python 3.7
-        with:
-          python-version: 3.7
+            - uses: actions/setup-python@v2
+              name: Install Python 3.7
+              with:
+                  python-version: 3.7
 
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==2
+            - name: Install cibuildwheel
+              run: |
+                  python -m pip install cibuildwheel==2
 
-      - name: Build wheel
-        run: |
-          python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_BUILD: cp*
+            - name: Build wheel
+              run: |
+                  python -m cibuildwheel --output-dir wheelhouse
+              env:
+                  CIBW_BUILD: cp*
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheels
-          path: ./wheelhouse
+            - uses: actions/upload-artifact@v2
+              with:
+                  name: wheels
+                  path: ./wheelhouse
 
-  pypi_upload:
-    needs: [build_src_wheel, build_plat_wheels]
-    name: Upload wheels to pypi
-    runs-on: ubuntu-18.04
-    if: github.event.release.published
+    pypi_upload:
+        needs: [build_src_wheel, build_plat_wheels]
+        name: Upload wheels to pypi
+        runs-on: ubuntu-18.04
+        if: github.event.release.published
 
-    steps:
-      - uses: actions/download-artifact@v2
-        with:
-          name: wheels
-          path: dist
+        steps:
+            - uses: actions/download-artifact@v2
+              with:
+                  name: wheels
+                  path: dist
 
-      - name: Publish package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.2
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+            - name: Publish package to PyPI
+              uses: pypa/gh-action-pypi-publish@v1.4.2
+              with:
+                  user: __token__
+                  password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,85 @@
+name: Build
+
+on:
+  push:
+  release:
+    types: [published]
+
+jobs:
+  build_src_wheel:
+    name: Build source wheel
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v2
+        name: Install Python 3.7
+        with:
+          python-version: 3.7
+
+      - name: Update to latest pip
+        run: |
+          python -m pip install -U setuptools pip wheel
+
+      - name: Build wheel
+        run: |
+          python setup.py sdist -d wheelhouse
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: wheelhouse
+
+  build_plat_wheels:
+    strategy:
+      matrix:
+        os: ["ubuntu-18.04", "windows-latest", "macos-latest"]
+
+    name: Build platform wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: actions/setup-python@v2
+        name: Install Python 3.7
+        with:
+          python-version: 3.7
+
+      - name: Install cibuildwheel
+        run: |
+          python -m pip install cibuildwheel==2
+
+      - name: Build wheel
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BUILD: cp*
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheels
+          path: ./wheelhouse
+
+  pypi_upload:
+    needs: [build_src_wheel, build_plat_wheels]
+    name: Upload wheels to pypi
+    runs-on: ubuntu-18.04
+    if: github.event.release.published
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: wheels
+          path: dist
+
+      - name: Publish package to PyPI
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,10 @@ name: Build
 
 on:
     push:
-    release:
-        types: [published]
+        branches:
+            - "**"
+        tags:
+            - "v*"
 
 jobs:
     build_src_wheel:
@@ -70,7 +72,7 @@ jobs:
         needs: [build_src_wheel, build_plat_wheels]
         name: Upload wheels to pypi
         runs-on: ubuntu-18.04
-        if: github.event.release.published
+        if: startsWith(github.ref, 'refs/tags')
 
         steps:
             - uses: actions/download-artifact@v2

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,14 @@ MANIFEST
 build*/
 dist/
 docs/_build
+epydoc/*
+make.py
 manifest
 pyswisseph.egg-info/*
 setup.cfg
+src
+swe_unix_src*
+swisseph.*.so
+swisseph.so
+
 venv/


### PR DESCRIPTION
This;
- Will make GHA (Github actions) compile the project in a CI build on every push
- Will make it also push the release to PyPi if it got triggered by a release itself.

This means;
- On every push to master, a new build run will go. It'll show the status next to the commit list, and if it fails (for whatever reason), it'll show a red checkmark. You can easily check up with this if the release fails to compile on whatever platform. (You can see that [here](https://github.com/astrorigin/pyswisseph/commits/pypi))
- On every release cut (in github), it'll compile again, and then publish the compilation artefacts to PyPi, automating a full release.

In the future, it'll be possible to make `cibuildwheel` (the program that makes this automated building possible) also test the release after every compilation, providing a "sanity check".

If any part of the building fails, it'll not publish upon release.
Consequently also, if there'd be test steps involved, and those fail, it'll not publish upon release.

If the release files already exist on PyPi, it'll also fail uploading them. This is a fail-safe, to make sure you don't publish files for the same release twice, or overwrite previous one. It's also impossible on the pypi side to overwrite existing files.