### PR TITLE
Update CI to support ARM MacOS (Apple Silicon)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,7 @@ jobs:
                   python -m cibuildwheel --output-dir wheelhouse
               env:
                   CIBW_BUILD: cp*
+                  CIBW_ARCHS: all
 
             - uses: actions/upload-artifact@v2
               with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
                   python -m cibuildwheel --output-dir wheelhouse
               env:
                   CIBW_BUILD: cp*
-                  CIBW_ARCHS: all
+                  CIBW_ARCHS_MACOS: universal2
 
             - uses: actions/upload-artifact@v2
               with:


### PR DESCRIPTION
As per [this build option](https://cibuildwheel.readthedocs.io/en/stable/options/#archs), this should automatically build pyswisseph for macOS ARM64, and compile it in one "universal" wheel.

This "universal" wheel would download and run the same on Intel (x86) and Apple Silicon (ARM64) MacOS alike, from the same download.