### PR TITLE
Unconstrain cibuildwheel from 2.0.0 to 2.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
 
             - name: Install cibuildwheel
               run: |
-                  python -m pip install cibuildwheel==2
+                  python -m pip install cibuildwheel~=2.0
 
             - name: Build wheel
               run: |


### PR DESCRIPTION
This would take advantage new features introduced in cibuilwheel, such as [building for `musllinux`](https://cibuildwheel.readthedocs.io/en/stable/changelog/#v220), which'd allow pyswisseph to run in musl (alpine) environments.